### PR TITLE
Mount image without uuid verification. Ref #2

### DIFF
--- a/lib/ec2/platform/linux/image.rb
+++ b/lib/ec2/platform/linux/image.rb
@@ -667,7 +667,7 @@ module EC2
           raise FatalError.new("image already mounted") if mounted?(IMG_MNT)
           dirs = ['mnt', 'proc', 'sys', 'dev']
           if self.is_disk_image?
-            execute( 'mount -t %s %s %s' % [@fstype, @target, IMG_MNT] )
+            execute( 'mount -o nouuid -t %s %s %s' % [@fstype, @target, IMG_MNT] )
             dirs.each{|dir| FileUtils.mkdir_p( '%s/%s' % [IMG_MNT, dir])}
             make_special_devices
             execute( 'mount -o bind /proc %s/proc' % IMG_MNT )

--- a/lib/ec2/version.rb
+++ b/lib/ec2/version.rb
@@ -3,6 +3,6 @@ require 'ec2/amitools/version'
 module EC2
   module AMITools
     VERSION_TOOLS = "#{EC2Version::PKG_VERSION}.#{EC2Version::PKG_RELEASE}".freeze
-    VERSION = "1.0.2"
+    VERSION = "1.0.3"
   end
 end


### PR DESCRIPTION
For some reason on CentOS 7 it's not possible to mount image as xfs filesystem.

Here is backtrace:
```sh
/usr/local/lib/ruby/gems/2.4.0/gems/ec2_amitools-1.0.2/lib/ec2/platform/linux/image.rb:793:in `execute': Failed to execute: 'mount -t xfs /dev/mapper/hda1 /mnt/img-mnt' (FatalError)
 from /usr/local/lib/ruby/gems/2.4.0/gems/ec2_amitools-1.0.2/lib/ec2/platform/linux/image.rb:670:in `mount_image'
 from /usr/local/lib/ruby/gems/2.4.0/gems/ec2_amitools-1.0.2/lib/ec2/platform/linux/image.rb:174:in `make'
 from /usr/local/lib/ruby/gems/2.4.0/gems/ec2_amitools-1.0.2/lib/ec2/amitools/bundlevol.rb:184:in `bundle_vol'
 from /usr/local/lib/ruby/gems/2.4.0/gems/ec2_amitools-1.0.2/lib/ec2/amitools/bundlevol.rb:231:in `main'
 from /usr/local/lib/ruby/gems/2.4.0/gems/ec2_amitools-1.0.2/lib/ec2/amitools/tool_base.rb:201:in `run'
 from /usr/local/lib/ruby/gems/2.4.0/gems/ec2_amitools-1.0.2/lib/ec2/amitools/bundlevol.rb:239:in `<top (required)>'
 from /usr/local/lib/ruby/gems/2.4.0/gems/ec2_amitools-1.0.2/bin/ec2-bundle-vol:6:in `load'
 from /usr/local/lib/ruby/gems/2.4.0/gems/ec2_amitools-1.0.2/bin/ec2-bundle-vol:6:in `<top (required)>'
 from /bin/ec2-bundle-vol:22:in `load'
 from /bin/ec2-bundle-vol:22:in `<main>'
```

Related topics:
https://www.centos.org/forums/viewtopic.php?t=51542
